### PR TITLE
Use ~2.0 instead of >=2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }],
     "require": {
         "php": ">=5.3.0",
-        "symfony/framework-bundle" : ">=2.0"
+        "symfony/framework-bundle" : "~2.0"
     },
     "require-dev": {
         "twig/extensions": "1.0.*"


### PR DESCRIPTION
Using `>=2.0` is dangerous because major version change could break your application.

It's more reliable to use `~2.0` instead.

See: https://getcomposer.org/doc/faqs/why-are-unbound-version-constraints-a-bad-idea.md